### PR TITLE
Refactor student_list.py

### DIFF
--- a/students_list.py
+++ b/students_list.py
@@ -11,8 +11,15 @@ names = []
 rolls = []
 
 class StudentsList:
-    """
-        
+    """ Stores the details of all students in a physical class
+
+        Attributes:
+            class_name: A string that contains the name of the physical class
+            
+        Class variables:
+            names: A list that contains the name of all students.
+            rolls: A list that contains the roll number of all students.
+
     """
     def __init__(self, class_name):
         """ :param str class_name: name of the physical class of a student"""

--- a/students_list.py
+++ b/students_list.py
@@ -11,11 +11,15 @@ names = []
 rolls = []
 
 class StudentsList:
+    """
+        
+    """
     def __init__(self, class_name):
-        """ :param str class_name: name of the class """
+        """ :param str class_name: name of the physical class of a student"""
         self.class_name = class_name
 
     def make_pkl_file(self):
+        """ Create a Pickle(.pkl) file"""
         pkl_file_path=Path(self.make_pkl_name())
         if pkl_file_path.exists():
             os.remove(pkl_file_path)
@@ -32,14 +36,22 @@ class StudentsList:
             pickle.dump(tupl, f, protocol = pickle.HIGHEST_PROTOCOL)
 
     def load_pkl_file(self):
+        """ Reads and returns the Pickle(.pkl) file containing data of the
+            physical class.
+        """
         with open(self.make_pkl_name(), 'rb') as f:
             return pickle.load(f)
 
     def make_xl_name(self):
-        """ Return the complete path of the Excel file containing the class data"""
+        """ Returns the complete pathname of the Excel(.xlsx) file containing
+            data of the  physical class.
+        """
         return join(getcwd(), "student's list", self.class_name + '.xlsx')
     
     def make_pkl_name(self):
+        """ Returns the complete pathname of the Pickle(.pkl) file containing
+            data of the physical class.
+        """
         return join(getcwd(), "student's list", self.class_name + '.pkl')
 
 

--- a/students_list.py
+++ b/students_list.py
@@ -12,32 +12,35 @@ rolls = []
 
 class StudentsList:
     def __init__(self, class_name):
+        """ :param str class_name: name of the class """
         self.class_name = class_name
 
     def make_pkl_file(self):
-        pkl_file_path=Path(self.make_pkl_name(self.class_name))
+        pkl_file_path=Path(self.make_pkl_name())
         if pkl_file_path.exists():
             os.remove(pkl_file_path)
-        wb = load_workbook(self.make_xl_name(self.class_name))
+        wb = load_workbook(self.make_xl_name())
         ws = wb.active
         number_of_studs = ws['A1'].value
+        # Get the name and roll number of all the students.
         for i in range(2, number_of_studs+2):
             names.append(ws['A'+str(i)].value)
             rolls.append(ws['B'+str(i)].value)
             
-        with open(self.make_pkl_name(self.class_name), 'wb') as f:
+        with open(self.make_pkl_name(), 'wb') as f:
             tupl = (names, rolls)
             pickle.dump(tupl, f, protocol = pickle.HIGHEST_PROTOCOL)
 
     def load_pkl_file(self):
-        with open(self.make_pkl_name(self.class_name), 'rb') as f:
+        with open(self.make_pkl_name(), 'rb') as f:
             return pickle.load(f)
 
-    def make_xl_name(self, class_name):
-        return join(getcwd(), "student's list", class_name + '.xlsx')
+    def make_xl_name(self):
+        """ Return the complete path of the Excel file containing the class data"""
+        return join(getcwd(), "student's list", self.class_name + '.xlsx')
     
-    def make_pkl_name(self, class_name):
-        return join(getcwd(), "student's list", class_name + '.pkl')
+    def make_pkl_name(self):
+        return join(getcwd(), "student's list", self.class_name + '.pkl')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What is this PR/ Why this PR?
This PR  refactors  [`StudentsList`](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/bb34f8780ecb6685ec074c30778febed1dcc0800/students_list.py#L13) class in the [student_list.py](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/master/students_list.py) by  

## Modifications:
- Removed the parameter `class_name` from the methods [`make_xl_name()`](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/bb34f8780ecb6685ec074c30778febed1dcc0800/students_list.py#L36) and [`make_pkl_name()`](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/bb34f8780ecb6685ec074c30778febed1dcc0800/students_list.py#L39).

**Reason**:
The methods [`make_xl_name()`](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/bb34f8780ecb6685ec074c30778febed1dcc0800/students_list.py#L36) and [`make_pkl_name()`](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/bb34f8780ecb6685ec074c30778febed1dcc0800/students_list.py#L39) earlier consumed `class_name`  to output the complete file path. However, this is not required as the `class_name` being an attribute of [`StudentsList`](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/bb34f8780ecb6685ec074c30778febed1dcc0800/students_list.py#L13) class in the [student_list.py](https://github.com/Marauders-9998/Attendance-Management-using-Face-Recognition/blob/master/students_list.py) can be accessed directly without explicit passing.
- Added _docstrings_ and a minor comment.

Signed-off-by: knn <kn.neelalohitha@gmail.com>